### PR TITLE
Update OpenAI model context length condition

### DIFF
--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -13,6 +13,9 @@ export const config = {
   runtime: 'edge',
 };
 
+const COMPLETION_TOKEN_LIMIT = 1000;
+const TOKENIZER_BUFFER_FACTOR = 0.9; // Set a buffer of 10% to account for any discrepancies in token counting
+
 const handler = async (req: Request): Promise<Response> => {
   try {
     const { model, messages, key, prompt, temperature } = (await req.json()) as ChatBody;
@@ -43,7 +46,7 @@ const handler = async (req: Request): Promise<Response> => {
       const message = messages[i];
       const tokens = encoding.encode(message.content);
 
-      if (tokenCount + tokens.length + 1000 > model.tokenLimit) {
+      if (tokenCount + tokens.length + COMPLETION_TOKEN_LIMIT > model.tokenLimit * TOKENIZER_BUFFER_FACTOR) {
         break;
       }
       tokenCount += tokens.length;


### PR DESCRIPTION
Modified the condition for checking the maximum context length in the OpenAI code to account for a slight discrepancy in token counting by the tokenizer in a third-party library. The tokenizer was counting the tokens slightly differently, leading to a context length error:

OpenAIError: This model's maximum context length is 4097 tokens. However, you requested 4170 tokens (3170 in the messages, 1000 in the completion). Please reduce the length of the messages or completion.

To prevent this error, I added a 10% buffer to the maximum context length. The new condition ensures that the maximum context length is not exceeded, while also accounting for any discrepancies in token counting.